### PR TITLE
docs: standardize TSDoc headers across all command schema files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,6 +2,19 @@
 
 ---
 
+### 🔴 HIGH PRIORITY — Template & Communication Infrastructure (NEXT)
+
+The template/communication items are the highest-impact next batch — they're guest-facing, table-stakes PMS features and the infrastructure (`communication_templates` + `automated_messages` + notification-service) already exists.
+
+**Phase 2 from PRO Analysis — Template & Communication:**
+- [ ] Communication templates table & schema (email/SMS/push templates with variable interpolation)
+- [ ] Automated messages table & schema (trigger-based messaging rules: pre-arrival, confirmation, post-stay)
+- [ ] Wire notification-service to use communication_templates for dynamic content rendering
+- [ ] Add command schemas for template CRUD and automated message configuration
+- [ ] Seed default templates (booking confirmation, pre-arrival, checkout, cancellation)
+
+---
+
 ### P0 — Reservation Flow Audit (2026-02-07)
 
 Full end-to-end trace of the reservation lifecycle across api-gateway, reservations-command-service, availability-guard-service, core-service, rooms-service, billing-service, guests-service, and schemas. Findings grouped by severity.

--- a/schema/src/events/commands/analytics.ts
+++ b/schema/src/events/commands/analytics.ts
@@ -1,12 +1,22 @@
 /**
  * DEV DOC
  * Module: events/commands/analytics.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Analytics command schemas for metric ingestion and report scheduling
+ * Primary exports: AnalyticsMetricIngestCommandSchema, AnalyticsReportScheduleCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 
 import { z } from "zod";
 
+/**
+ * Ingest a single analytics metric data point.
+ * Records a metric value with optional dimensions for
+ * downstream aggregation and dashboard reporting.
+ *
+ * @category commands
+ * @synchronized 2026-02-18
+ */
 export const AnalyticsMetricIngestCommandSchema = z.object({
 	metric_code: z.string().min(2).max(100),
 	value: z.coerce.number(),
@@ -21,6 +31,14 @@ export type AnalyticsMetricIngestCommand = z.infer<
 	typeof AnalyticsMetricIngestCommandSchema
 >;
 
+/**
+ * Schedule or update a recurring analytics report.
+ * Configures periodic generation of reports with
+ * specified parameters and delivery settings.
+ *
+ * @category commands
+ * @synchronized 2026-02-18
+ */
 export const AnalyticsReportScheduleCommandSchema = z.object({
 	report_id: z.string().uuid(),
 	schedule_config: z.record(z.unknown()),

--- a/schema/src/events/commands/billing.ts
+++ b/schema/src/events/commands/billing.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/billing.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Billing command schemas for payments, invoices, folios, commissions, AR, cashier, and dynamic pricing
+ * Primary exports: BillingPaymentCaptureCommandSchema, BillingChargePostCommandSchema, BillingNightAuditCommandSchema, CommissionCalculateCommandSchema, BillingArPostCommandSchema, BillingCashierOpenCommandSchema, BillingPricingEvaluateCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/compliance.ts
+++ b/schema/src/events/commands/compliance.ts
@@ -1,12 +1,22 @@
 /**
  * DEV DOC
  * Module: events/commands/compliance.ts
- * Purpose: Command schemas for compliance domain (breach reporting, notifications).
+ * Description: Compliance command schemas for data breach reporting and notification
+ * Primary exports: ComplianceBreachReportCommandSchema, ComplianceBreachNotifyCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 
 import { z } from "zod";
 
+/**
+ * Report a data breach or security incident.
+ * Creates an incident record with severity classification,
+ * affected data categories, and systems for regulatory tracking.
+ *
+ * @category commands
+ * @synchronized 2026-02-18
+ */
 export const ComplianceBreachReportCommandSchema = z.object({
 	property_id: z.string().uuid().optional(),
 	incident_title: z.string().min(1).max(300),
@@ -37,6 +47,14 @@ export type ComplianceBreachReportCommand = z.infer<
 	typeof ComplianceBreachReportCommandSchema
 >;
 
+/**
+ * Notify authorities and affected data subjects about a breach.
+ * Triggers regulatory notifications and optional subject alerts
+ * per GDPR/privacy requirements.
+ *
+ * @category commands
+ * @synchronized 2026-02-18
+ */
 export const ComplianceBreachNotifyCommandSchema = z.object({
 	incident_id: z.string().uuid(),
 	authority_reference: z.string().max(200).optional(),

--- a/schema/src/events/commands/groups.ts
+++ b/schema/src/events/commands/groups.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/groups.ts
- * Purpose: Zod schemas for group booking command payloads.
+ * Description: Group booking command schemas for creation, room blocks, rooming lists, cutoff enforcement, and billing setup
+ * Primary exports: GroupCreateCommandSchema, GroupAddRoomsCommandSchema, GroupUploadRoomingListCommandSchema, GroupCutoffEnforceCommandSchema, GroupBillingSetupCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/guests.ts
+++ b/schema/src/events/commands/guests.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/guests.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Guest command schemas for registration, profile updates, loyalty, VIP, blacklist, GDPR, and preferences
+ * Primary exports: GuestRegisterCommandSchema, GuestMergeCommandSchema, GuestUpdateProfileCommandSchema, GuestSetLoyaltyCommandSchema, GuestGdprEraseCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/housekeeping.ts
+++ b/schema/src/events/commands/housekeeping.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/housekeeping.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Housekeeping command schemas for task assignment, completion, reassignment, and bulk status updates
+ * Primary exports: HousekeepingAssignCommandSchema, HousekeepingCompleteCommandSchema, HousekeepingTaskCreateCommandSchema, HousekeepingTaskBulkStatusCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/integrations.ts
+++ b/schema/src/events/commands/integrations.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/integrations.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Integration command schemas for OTA sync, rate push, webhook retry, and mapping updates
+ * Primary exports: IntegrationOtaSyncRequestCommandSchema, IntegrationOtaRatePushCommandSchema, IntegrationWebhookRetryCommandSchema, IntegrationMappingUpdateCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/inventory.ts
+++ b/schema/src/events/commands/inventory.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/inventory.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Inventory command schemas for room locking, releasing, and bulk release via availability guard
+ * Primary exports: InventoryLockRoomCommandSchema, InventoryReleaseRoomCommandSchema, InventoryBulkReleaseCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/notifications.ts
+++ b/schema/src/events/commands/notifications.ts
@@ -1,3 +1,12 @@
+/**
+ * DEV DOC
+ * Module: events/commands/notifications.ts
+ * Description: Notification command schemas for guest communication dispatch
+ * Primary exports: NotificationSendCommandSchema
+ * @category commands
+ * Ownership: Schema package
+ */
+
 import { z } from "zod";
 
 /**

--- a/schema/src/events/commands/operations.ts
+++ b/schema/src/events/commands/operations.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/operations.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Operations command schemas for maintenance requests, incidents, asset tracking, inventory adjustments, and staff scheduling
+ * Primary exports: OperationsMaintenanceRequestCommandSchema, OperationsIncidentReportCommandSchema, OperationsScheduleCreateCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/reservations.ts
+++ b/schema/src/events/commands/reservations.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/reservations.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Reservation command schemas for the full booking lifecycle — create, modify, cancel, check-in/out, deposits, no-show, walk-in, waitlist, registration cards, and mobile check-in
+ * Primary exports: ReservationCreateCommandSchema, ReservationCheckInCommandSchema, ReservationCheckOutCommandSchema, ReservationWalkGuestCommandSchema, ReservationMobileCheckinStartCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/rooms.ts
+++ b/schema/src/events/commands/rooms.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/rooms.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Room command schemas for status updates, housekeeping, maintenance, room moves, features, and digital key management
+ * Primary exports: RoomStatusUpdateCommandSchema, RoomMoveCommandSchema, RoomKeyIssueCommandSchema, RoomOutOfOrderCommandSchema, RoomInventoryBlockCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 

--- a/schema/src/events/commands/settings.ts
+++ b/schema/src/events/commands/settings.ts
@@ -1,7 +1,9 @@
 /**
  * DEV DOC
  * Module: events/commands/settings.ts
- * Purpose: Shared schema/type definitions and validation helpers.
+ * Description: Settings command schemas for value set, bulk set, approval, and reversion across tenant/property/user scopes
+ * Primary exports: SettingsValueSetCommandSchema, SettingsValueBulkSetCommandSchema, SettingsValueApproveCommandSchema, SettingsValueRevertCommandSchema
+ * @category commands
  * Ownership: Schema package
  */
 


### PR DESCRIPTION
## Summary

- Update DEV DOC headers in all 13 command schema files to match loyalty.ts standard
- Add specific Description, Primary exports, and @category tags
- Add per-schema TSDoc with business context for analytics and compliance commands
- Add missing DEV DOC header to notifications.ts
- Add Template & Communication as 🔴 HIGH PRIORITY TODO (Phase 2 PRO analysis)

## Changes

**Command schemas updated (13 files):**
analytics.ts, billing.ts, compliance.ts, groups.ts, guests.ts, housekeeping.ts, integrations.ts, inventory.ts, notifications.ts, operations.ts, reservations.ts, rooms.ts, settings.ts

**TODO.md:** Added Phase 2 Template & Communication section as next high priority work.